### PR TITLE
Port: newgrp-cannot-change-to-group-with-password

### DIFF
--- a/multihost_test/Bugzillas/data/bz672510_1.sh
+++ b/multihost_test/Bugzillas/data/bz672510_1.sh
@@ -1,0 +1,22 @@
+# Adds password to the group. The group must exist
+# $1 - group
+# $2 - password
+function groupPasswordAdd() {
+    expect -c "
+        spawn gpasswd $1
+        expect {
+            {New} { send -- $2\r }
+            default { exit 1 }
+        }
+        expect {
+            {Re} { send -- $2\r }
+            default { exit 2 }
+        }
+        expect {eof} { exit 0 }
+        expect 3
+    "
+
+    # return expect exit code
+    return $?
+}
+groupPasswordAdd $1 $2

--- a/multihost_test/Bugzillas/data/bz672510_2.sh
+++ b/multihost_test/Bugzillas/data/bz672510_2.sh
@@ -1,0 +1,31 @@
+# Test newgroup with password
+# $1 - user to test
+# $2 - group
+# $3 - group password
+function newgrpTestPass() {
+    expect -c "
+        spawn su - $1
+        expect {
+            {$1} { send -- \"newgrp $2\r\" }
+            default { exit 1 }
+        }
+        expect {
+            {Password} { send -- $3\r }
+            {exist} { exit 2 }
+            default { exit 2 }
+        }
+        expect {
+            {Invalid} { exit 3 }
+            {$1} { send -- groups\r }
+        }
+        expect {$1} { send -- exit\r }
+        expect {
+            {$1} { send -- exit\r }
+            eof { exit 0 }
+        }
+        expect eof { exit 0 }
+    "
+
+    return $?
+}
+newgrpTestPass $1 $2 $3

--- a/multihost_test/Bugzillas/data/bz672510_3.sh
+++ b/multihost_test/Bugzillas/data/bz672510_3.sh
@@ -1,0 +1,28 @@
+# Test newgroup with password
+# $1 - user to test
+# $2 - group
+function newgrpTestNoPass() {
+    expect -c "
+        spawn su - $1
+        expect {
+            {$1} { send -- \"newgrp $2\r\" }
+            default { exit 1 }
+        }
+        expect {
+            {$1} { send -- groups\r }
+            {Password} { exit 2 }
+        }
+        expect {
+            {$1} { send -- exit\r }
+            default { exit 3 }
+        }
+        expect {
+            {$1} { send -- exit\r }
+            default { exit 4 }
+        }
+        expect eof { exit 0 }
+    "
+
+    return $?
+}
+newgrpTestNoPass $1 $2

--- a/multihost_test/Bugzillas/test_bz_automation.py
+++ b/multihost_test/Bugzillas/test_bz_automation.py
@@ -63,3 +63,61 @@ class TestShadowBz(object):
         result = execute_cmd(multihost, 'su - local_anuj -c "podman run fedora cat /proc/self/uid_map"').stdout_text
         for i in execute_cmd(multihost, f"grep {user_uid} /etc/subuid").stdout_text[:-1].split(":"):
             assert i in result.split()
+
+    def test_bz672510(self, multihost):
+        """
+        :title: Checks if newgrp command works properly
+         for password protected groups
+        :id: f2bb9b8e-39a9-11ed-88a4-845cf3eff344
+        :bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=672510
+        :steps:
+          1. newgrp works for password protected group with correct password
+          2. Adding password to group
+          3. Trying good password with newgrp
+          4. newgrp doesn't work for password protected group with incorrect password
+          5. newgrp doesn't work for non existing group
+          6. newgrp doesn't work for not password protected group for non-member
+          7. newgrp works for not password protected group for member
+        :expectedresults:
+          1. Should succeed
+          2. Should succeed
+          3. Should succeed
+          4. Should succeed
+          5. Should succeed
+          6. Should succeed
+          7. Should succeed
+        """
+        execute_cmd(multihost, 'yum install -y expect')
+        tgroup = "tgroup00011"
+        tuser = "tuser1"
+        tuser2 = "tuser2"
+        file_location = "/multihost_test/Bugzillas/data/"
+        for file in [f'{file_location}bz672510_1.sh',
+                     f'{file_location}bz672510_2.sh',
+                     f'{file_location}bz672510_3.sh']:
+            multihost.client[0].transport.put_file(os.getcwd()+f'/{file}', f'/tmp/{file}')
+            execute_cmd(multihost, f"chmod 755 /tmp/{file}")
+        # newgrp works for password protected group with correct password
+        execute_cmd(multihost, f"useradd {tuser}")
+        execute_cmd(multihost, f"groupadd {tgroup}")
+        # Adding password to group
+        execute_cmd(multihost, f"sh /tmp/bz672510_1.sh {tgroup} {tgroup}")
+        # Trying good password with newgrp
+        execute_cmd(multihost, f"sh /tmp/bz672510_2.sh {tuser} {tgroup} {tgroup}")
+        # newgrp doesn't work for password protected group with incorrect password
+        with pytest.raises(subprocess.CalledProcessError):
+            execute_cmd(multihost, f"sh /tmp/bz672510_2.sh {tuser} {tgroup} badpass")
+        # newgrp doesn't work for non existing group
+        with pytest.raises(subprocess.CalledProcessError):
+            execute_cmd(multihost, f"sh /tmp/bz672510_2.sh {tuser} badgroup badpass")
+        # newgrp doesn't work for not password protected group for non-member
+        execute_cmd(multihost, f'gpasswd -r {tgroup}')
+        # Trying good password with newgrp for non-member
+        with pytest.raises(subprocess.CalledProcessError):
+            execute_cmd(multihost, f"sh /tmp/bz672510_2.sh {tuser} {tgroup} {tgroup}")
+        # newgrp works for not password protected group for member
+        execute_cmd(multihost, f"gpasswd -M {tuser} {tgroup}")
+        # Trying no password with newgrp for group member
+        execute_cmd(multihost, f"sh /tmp/bz672510_3.sh {tuser} {tgroup}")
+        execute_cmd(multihost, f"userdel -rf {tuser}")
+        execute_cmd(multihost, f"groupdel  {tgroup}")


### PR DESCRIPTION
https://pkgs.devel.redhat.com/cgit/tests/shadow-utils/tree/Regression/bz672510-newgrp-cannot-change-to-group-with-password